### PR TITLE
Run test suites in parallel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,27 +3,22 @@ name: Build
 on: [pull_request]
 
 jobs:
-  build:
+
+  test-suite:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        suite-name: ["com.twitter.intellij.pants.Suite1", "com.twitter.intellij.pants.Suite2"]
         os: [ubuntu-latest]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2.0.0
-      - run: git fetch --prune --unshallow
       - name: Prepare the container
         run: |
           docker build --tag ideprobe-pants:local .
-      - name: Suite 1
+      - name: Run ${{ matrix.suite-name }}
         env:
-          TEST_PATTERN: "com.twitter.intellij.pants.Suite1"
-        run: |
-          echo $TEST_PATTERN
-          ./ci/run_docker.sh bash ci/test.sh
-      - name: Suite 2
-        env:
-          TEST_PATTERN: "com.twitter.intellij.pants.Suite2"
+          TEST_PATTERN: ${{ matrix.suite-name }}
         run: |
           echo $TEST_PATTERN
           ./ci/run_docker.sh bash ci/test.sh


### PR DESCRIPTION
The Docker image turned out to be more than 600 megabytes large, so building it twice is much more efficient than uploading and downloading.