### PR TITLE
Install Rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
 FROM lwawrzyk/ideprobe-pants:202.6948.69
+RUN which curl \
+  && curl -LsO "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" \
+  && chmod +x rustup-init \
+  && ./rustup-init -yq
 ADD . /workspace
 WORKDIR /workspace

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -4,6 +4,7 @@ set -x
 export IDEPROBE_DISPLAY=xvfb
 
 apt install -y zip
+which rustc
 if [ -z "${TEST_PATTERN}" ]; then
   sbt "pantsTests/test"
 else


### PR DESCRIPTION
The Rust files cached in the base Docker image seem to come from the version 1.42.0, whereas the Pants installer seems to use the version 1.46.0, which is also the latest stable version. I hope pre-installing it will speed up the CI.