### PR TITLE
Remove redundant files from the CI runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/share/swift
           sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/hostedtoolcache
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/az
           df -h
       - name: Prepare the container
         run: |

--- a/.github/workflows/prepare-image.yml
+++ b/.github/workflows/prepare-image.yml
@@ -19,6 +19,9 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/share/swift
           sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/hostedtoolcache
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/az
           df -h
       - name: Prepare the image
         run: |


### PR DESCRIPTION
This doesn't affect the contents of the Docker image or the way tests are executed.