### PR TITLE
Test for the "Rerun failed tests" button

### DIFF
--- a/tests/src/test/resources/RunFailedTestsTest.conf
+++ b/tests/src/test/resources/RunFailedTestsTest.conf
@@ -1,0 +1,10 @@
+include required("projects/PantsExample/ideprobe.conf")
+
+pants.import.targets = ["failingtests/src/test/scala::"]
+
+runConfiguration {
+  bsp {
+    module.name = "failingtests_src_test_scala:scala",
+    runnerNameFragment = "ScalaTest"
+  }
+}

--- a/tests/src/test/resources/projects/PantsExample/failingtests/src/test/scala/BUILD
+++ b/tests/src/test/resources/projects/PantsExample/failingtests/src/test/scala/BUILD
@@ -1,0 +1,7 @@
+junit_tests(
+    sources = ['com/example/FailingTests.scala'],
+    dependencies=[
+        '3rdparty:junit',
+        '3rdparty:scalatest',
+    ],
+)

--- a/tests/src/test/resources/projects/PantsExample/failingtests/src/test/scala/com/example/FailingTests.scala
+++ b/tests/src/test/resources/projects/PantsExample/failingtests/src/test/scala/com/example/FailingTests.scala
@@ -1,0 +1,18 @@
+package com.example
+
+import org.junit.runner.RunWith
+import org.scalatest.WordSpec
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.MustMatchers
+
+@RunWith(classOf[JUnitRunner])
+class Addition extends WordSpec with MustMatchers {
+  "1 + 1" should {
+    "equal 2" in {
+      (1 + 1) mustEqual 2
+    }
+    "equal 3" in {
+      (1 + 1) mustEqual 3
+    }
+  }
+}

--- a/tests/src/test/scala/com/twitter/intellij/pants/RunFailedTestsTest.scala
+++ b/tests/src/test/scala/com/twitter/intellij/pants/RunFailedTestsTest.scala
@@ -1,0 +1,42 @@
+package com.twitter.intellij.pants
+
+import org.junit.Assert._
+import org.junit.Test
+import org.virtuslab.ideprobe.ConfigFormat
+import org.virtuslab.ideprobe.RunningIntelliJFixture
+import org.virtuslab.ideprobe.protocol.{ProjectRef, TestRunConfiguration}
+
+class RunFailedTestsTest extends PantsTestSuite with ConfigFormat {
+
+  @Test def runTestsWithBsp(): Unit = {
+    runTests("bsp", openProjectWithBsp, _.probe.build().assertSuccess())
+  }
+
+  //TODO add a test case for a Pants project (like in RunTestsTest)
+
+  private def runTests(
+    configSuffix: String,
+    openProject: RunningIntelliJFixture => ProjectRef,
+    buildProject: RunningIntelliJFixture => Unit
+  ): Unit = {
+    import pureconfig.generic.auto._
+    fixtureFromConfig().run { intelliJ =>
+      openProject(intelliJ)
+      buildProject(intelliJ)
+
+      val runConfiguration = intelliJ.config[TestRunConfiguration](s"runConfiguration.$configSuffix")
+      val moduleName = runConfiguration.module.name
+
+      val result = intelliJ.probe.run(runConfiguration)
+      val errorsInitial = intelliJ.probe.errors
+      assertEquals(s"number of test suites in in $moduleName", 1, result.suites.size)
+      assertEquals("initial number of errors", errorsInitial.size, 2)
+      assertEquals("initial test results", Set("Tests failed: 1, passed: 1"), errorsInitial.map(_.content).toSet)
+      intelliJ.probe.invokeAction("RerunFailedTests")
+      val errorsRerun = intelliJ.probe.errors.filterNot(errorsInitial.contains)
+      assertEquals("number of rerun errors", errorsInitial.size, 2)
+      assertEquals("rerun results", Set("Tests failed: 1, passed: 0"), errorsRerun.map(_.content).toSet)
+    }
+  }
+
+}

--- a/tests/src/test/scala/com/twitter/intellij/pants/Suites.scala
+++ b/tests/src/test/scala/com/twitter/intellij/pants/Suites.scala
@@ -19,6 +19,7 @@ class Suite1
 @RunWith(classOf[Suite])
 @SuiteClasses(Array(
   classOf[RunAppTest],
-  classOf[RunTestsTest]
+  classOf[RunTestsTest],
+  classOf[RunFailedTestsTest]
 ))
 class Suite2


### PR DESCRIPTION
This test covers only BSP projects, because it seems that the structure of a generated Pants project is not compatible with Scalatest requests by the robot. I'm going to address this problem in another pull request.