### PR TITLE
Fix the update checker crash

### DIFF
--- a/ci/update-checker/src/main/scala/com/twitter/intellij/updatechecker/UpdateChecker.scala
+++ b/ci/update-checker/src/main/scala/com/twitter/intellij/updatechecker/UpdateChecker.scala
@@ -75,14 +75,18 @@ object UpdateChecker {
       def getUpdateInfo(id: String, version: String) = pluginUpdateManager.getUpdatesByVersionAndFamily(
         id, version, ProductFamily.INTELLIJ
       ).asScala.toList
-      val availableUpdate = updates.head
-      val availableVersion = availableUpdate.getVersion
-      val currentUpdateInfo = getUpdateInfo(p.id, p.version).head
-      val availableUpdateInfo = getUpdateInfo(p.id, availableVersion).head
-      val isNewer = currentUpdateInfo < availableUpdateInfo
-      println((if(isNewer) "!" else " ") + s" ${availableVersion} is ${if(isNewer) "" else "not "}newer than ${currentUpdateInfo.getVersion}")
-      println()
-      if(isNewer) Some(PluginUpdate(p.id, availableVersion)) else None
+      if(updates.isEmpty) {
+        println(s"No updates found for ${p.id} ${p.version}. Something is not right...")
+      }
+      updates.headOption.flatMap { availableUpdate =>
+        val availableVersion = availableUpdate.getVersion
+        val currentUpdateInfo = getUpdateInfo(p.id, p.version).head
+        val availableUpdateInfo = getUpdateInfo(p.id, availableVersion).head
+        val isNewer = currentUpdateInfo < availableUpdateInfo
+        println((if(isNewer) "!" else " ") + s" ${availableVersion} is ${if(isNewer) "" else "not "}newer than ${currentUpdateInfo.getVersion}")
+        println()
+        if(isNewer) Some(PluginUpdate(p.id, availableVersion)) else None
+      }
     }
 
     val pluginUpdates = currentPlugins.collect {


### PR DESCRIPTION
The crashes were caused by unexpected response from the server: the list of available versions for the Thrift plugin was empty. Usually this list contains at least one plugin version (the latest one), even if it is the same or older than the current one. Curiously, when I run the checker on my macbook, it receives correct information about the latest versions of all plugins, including Thrift.