### PR TITLE
Bumped the Thrift plugin to version 1.4.0.

### DIFF
--- a/tests/src/test/resources/versions.conf
+++ b/tests/src/test/resources/versions.conf
@@ -8,7 +8,7 @@ versions {
       repository = { path = "https://github.com/tpasternak/intellij-pants-plugin.git", ref = "bump-203-pr-1.26.x" }
       env = { "PANTS_SHA" = "1.25.x-twtr" }
     }
-    thrift = { id = "com.intellij.plugins.thrift", version = "1.3.2" }
+    thrift = { id = "com.intellij.plugins.thrift", version = "1.4.0" }
   }
   tools {
     fastpass.version = "1.7.0"


### PR DESCRIPTION
I created this pull request manually to see if the tests would pass. The automatic update checker still behaves in a strange way.