### PR TITLE
Common test fixture

### DIFF
--- a/ci/setup/src/test/scala/com/twitter/intellij/pants/PreparePants.scala
+++ b/ci/setup/src/test/scala/com/twitter/intellij/pants/PreparePants.scala
@@ -6,9 +6,9 @@ import org.virtuslab.ideprobe.{Config, IntelliJFixture}
 import org.virtuslab.ideprobe.Extensions._
 import org.virtuslab.ideprobe.dependencies.Plugin
 import org.virtuslab.ideprobe.pants.PantsSetup
-import org.virtuslab.tests.pants.PantsTestSuite
+import org.virtuslab.tests.IdeProbeTest
 
-class PreparePants extends PantsTestSuite {
+class PreparePants extends IdeProbeTest {
   @Test def run(): Unit = {
     val fixture = IntelliJFixture
       .fromConfig(Config.fromClasspath("base.conf"))

--- a/tests/src/test/scala/org/virtuslab/tests/IdeProbeTest.scala
+++ b/tests/src/test/scala/org/virtuslab/tests/IdeProbeTest.scala
@@ -1,9 +1,11 @@
-package org.virtuslab.tests.pants
+package org.virtuslab.tests
 
+import org.virtuslab.ideprobe.bazel.BazelPluginExtension
 import org.virtuslab.ideprobe.junit4.IdeProbeTestSuite
 import org.virtuslab.ideprobe.pants.{PantsPluginExtension, PantsPluginExtraExtensions}
 
-trait PantsTestSuite
+trait IdeProbeTest
   extends IdeProbeTestSuite
     with PantsPluginExtension
     with PantsPluginExtraExtensions
+    with BazelPluginExtension

--- a/tests/src/test/scala/org/virtuslab/tests/bazel/BazelProjectOpenBenchmark.scala
+++ b/tests/src/test/scala/org/virtuslab/tests/bazel/BazelProjectOpenBenchmark.scala
@@ -2,8 +2,8 @@ package org.virtuslab.tests.bazel
 
 import org.junit.Test
 import org.virtuslab.ideprobe.DurationCheckFixture
-import org.virtuslab.tests.bazel.OpenProjectTestBazel
+import org.virtuslab.tests.IdeProbeTest
 
-class BazelProjectOpenBenchmark extends BazelTestSuite with DurationCheckFixture {
+class BazelProjectOpenBenchmark extends IdeProbeTest with DurationCheckFixture {
   @Test def bazel(): Unit = checkDuration("bazel", openProjectWithBazel(_))
 }

--- a/tests/src/test/scala/org/virtuslab/tests/bazel/BazelTestSuite.scala
+++ b/tests/src/test/scala/org/virtuslab/tests/bazel/BazelTestSuite.scala
@@ -1,6 +1,0 @@
-package org.virtuslab.tests.bazel
-
-import org.virtuslab.ideprobe.bazel.BazelPluginExtension
-import org.virtuslab.ideprobe.junit4.IdeProbeTestSuite
-
-trait BazelTestSuite extends IdeProbeTestSuite with BazelPluginExtension

--- a/tests/src/test/scala/org/virtuslab/tests/bazel/OpenProjectTestBazel.scala
+++ b/tests/src/test/scala/org/virtuslab/tests/bazel/OpenProjectTestBazel.scala
@@ -3,11 +3,11 @@ package org.virtuslab.tests.bazel
 import org.junit.{Assert, Test}
 import org.virtuslab.ideprobe.RunningIntelliJFixture
 import org.virtuslab.ideprobe.protocol.{ProjectRef, TestScope}
-import org.virtuslab.tests.{OpenProjectTest, OpenProjectTestFixture}
+import org.virtuslab.tests.{IdeProbeTest, OpenProjectTest, OpenProjectTestFixture}
 
 
 object OpenProjectTestBazel
-  extends BazelTestSuite
+  extends IdeProbeTest
     with OpenProjectTestFixture {
 
   override def openProject(): ProjectRef = openProjectWithBazel(intelliJ)
@@ -15,7 +15,7 @@ object OpenProjectTestBazel
 }
 
 // JDK11 only!
-class OpenProjectTestBazel extends BazelTestSuite with OpenProjectTest {
+class OpenProjectTestBazel extends IdeProbeTest with OpenProjectTest {
 
   override def intelliJ: RunningIntelliJFixture = OpenProjectTestBazel.intelliJ
 

--- a/tests/src/test/scala/org/virtuslab/tests/pants/BUILDFilesTest.scala
+++ b/tests/src/test/scala/org/virtuslab/tests/pants/BUILDFilesTest.scala
@@ -9,8 +9,9 @@ import org.virtuslab.ideprobe.protocol.ProjectRef
 import org.virtuslab.ideprobe.protocol.Reference
 import org.virtuslab.ideprobe.Extensions._
 import org.virtuslab.ideprobe.dependencies.Plugin
+import org.virtuslab.tests.IdeProbeTest
 
-final class BUILDFilesTest extends PantsTestSuite with Assertions {
+final class BUILDFilesTest extends IdeProbeTest with Assertions {
 
   // bazel overrides handling of BUILD files that is in pants plugin
   registerFixtureTransformer { fixture =>

--- a/tests/src/test/scala/org/virtuslab/tests/pants/PantsOpenProjectBenchmark.scala
+++ b/tests/src/test/scala/org/virtuslab/tests/pants/PantsOpenProjectBenchmark.scala
@@ -2,8 +2,9 @@ package org.virtuslab.tests.pants
 
 import org.junit.Test
 import org.virtuslab.ideprobe.DurationCheckFixture
+import org.virtuslab.tests.IdeProbeTest
 
-class PantsOpenProjectBenchmark extends PantsTestSuite with DurationCheckFixture {
+class PantsOpenProjectBenchmark extends IdeProbeTest with DurationCheckFixture {
   @Test def pants(): Unit = checkDuration("pants", openProjectWithPants(_))
 
   @Test def bsp(): Unit = checkDuration("bsp", openProjectWithBsp(_))

--- a/tests/src/test/scala/org/virtuslab/tests/pants/PantsSettingsTest.scala
+++ b/tests/src/test/scala/org/virtuslab/tests/pants/PantsSettingsTest.scala
@@ -4,8 +4,9 @@ import org.junit.Assert._
 import org.junit.Test
 import org.virtuslab.ideprobe.pants.protocol.PantsProjectSettingsChangeRequest
 import org.virtuslab.ideprobe.protocol.Setting
+import org.virtuslab.tests.IdeProbeTest
 
-class PantsSettingsTest extends PantsTestSuite {
+class PantsSettingsTest extends IdeProbeTest {
 
   @Test def importProjectWithCustomSettings(): Unit = {
     fixtureFromConfig().run { intelliJ =>

--- a/tests/src/test/scala/org/virtuslab/tests/pants/RerunFailedTestsTest.scala
+++ b/tests/src/test/scala/org/virtuslab/tests/pants/RerunFailedTestsTest.scala
@@ -4,9 +4,10 @@ import org.junit.Assert._
 import org.junit.Test
 import org.virtuslab.ideprobe.{RunningIntelliJFixture, WaitLogic}
 import org.virtuslab.ideprobe.protocol.{ProjectRef, TestScope}
+import org.virtuslab.tests.IdeProbeTest
 import scala.concurrent.duration.DurationInt
 
-class RerunFailedTestsTest extends PantsTestSuite {
+class RerunFailedTestsTest extends IdeProbeTest {
 
   @Test def runTestsWithBsp(): Unit = {
     runTests("bsp", openProjectWithBsp(_), _.probe.build().assertSuccess())

--- a/tests/src/test/scala/org/virtuslab/tests/pants/RunAppTest.scala
+++ b/tests/src/test/scala/org/virtuslab/tests/pants/RunAppTest.scala
@@ -6,8 +6,9 @@ import org.virtuslab.ideprobe.ConfigFormat
 import org.virtuslab.ideprobe.RunningIntelliJFixture
 import org.virtuslab.ideprobe.protocol.ApplicationRunConfiguration
 import org.virtuslab.ideprobe.protocol.ProjectRef
+import org.virtuslab.tests.IdeProbeTest
 
-class RunAppTest extends PantsTestSuite with ConfigFormat {
+class RunAppTest extends IdeProbeTest with ConfigFormat {
 
   @Test
   def runsMainClassWithPants(): Unit = {

--- a/tests/src/test/scala/org/virtuslab/tests/pants/RunTestsTest.scala
+++ b/tests/src/test/scala/org/virtuslab/tests/pants/RunTestsTest.scala
@@ -5,8 +5,9 @@ import org.junit.Test
 import org.virtuslab.ideprobe.ConfigFormat
 import org.virtuslab.ideprobe.RunningIntelliJFixture
 import org.virtuslab.ideprobe.protocol.{ProjectRef, TestScope}
+import org.virtuslab.tests.IdeProbeTest
 
-class RunTestsTest extends PantsTestSuite with ConfigFormat {
+class RunTestsTest extends IdeProbeTest with ConfigFormat {
 
   @Test def runTestsWithBsp(): Unit = {
     runTests("bsp", openProjectWithBsp(_), _.probe.build().assertSuccess())

--- a/tests/src/test/scala/org/virtuslab/tests/pants/ThriftIdeaPluginTest.scala
+++ b/tests/src/test/scala/org/virtuslab/tests/pants/ThriftIdeaPluginTest.scala
@@ -5,8 +5,9 @@ import org.virtuslab.ideprobe.{Assertions, ConfigFormat, RunningIntelliJFixture}
 import org.virtuslab.ideprobe.protocol.NavigationQuery
 import org.virtuslab.ideprobe.protocol.NavigationTarget
 import org.virtuslab.ideprobe.protocol.ProjectRef
+import org.virtuslab.tests.IdeProbeTest
 
-final class ThriftIdeaPluginTest extends PantsTestSuite with Assertions with ConfigFormat {
+final class ThriftIdeaPluginTest extends IdeProbeTest with Assertions with ConfigFormat {
 
   @Test
   def findThriftFilesPants(): Unit = {

--- a/tests/src/test/scala/org/virtuslab/tests/pants/open/OpenProjectTestFixturePants.scala
+++ b/tests/src/test/scala/org/virtuslab/tests/pants/open/OpenProjectTestFixturePants.scala
@@ -1,9 +1,8 @@
 package org.virtuslab.tests.pants.open
 
-import org.virtuslab.tests.OpenProjectTestFixture
-import org.virtuslab.tests.pants.PantsTestSuite
+import org.virtuslab.tests.{OpenProjectTestFixture, IdeProbeTest}
 
 trait OpenProjectTestFixturePants
-  extends PantsTestSuite
+  extends IdeProbeTest
   with OpenProjectTestFixture
 


### PR DESCRIPTION
I already unified bazel and pants tests to use the same config, specifically the same set of plugins, in order to detect any conflicts if both pants and bazel plugins are installed. Another step of this unification is to use common base trait for tests.
Additionally it will be easier to add custom modifications for forks of this repo in one place. For example, now, accidentally, we don't disable android and kotlin plugins in bazel tests.