### PR TITLE
Try bumping Coursier in CI

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,7 +2,7 @@
 set -x
 
 export IDEPROBE_DISPLAY=xvfb
-export FASTPASS_COURSIER_URL=https://github.com/coursier/coursier/releases/download/v2.0.14/coursier
+export FASTPASS_COURSIER_URL=https://github.com/coursier/coursier/releases/download/v2.1.0-RC5/coursier
 
 if [ -z "${TEST_PATTERN}" ]; then
   sbt "$TEST_TARGET/test"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,7 +2,7 @@
 set -x
 
 export IDEPROBE_DISPLAY=xvfb
-export FASTPASS_COURSIER_URL=https://github.com/coursier/coursier/releases/download/v2.0.13/coursier
+export FASTPASS_COURSIER_URL=https://github.com/coursier/coursier/releases/download/v2.0.14/coursier
 
 if [ -z "${TEST_PATTERN}" ]; then
   sbt "$TEST_TARGET/test"


### PR DESCRIPTION
I don't know what has changed since PR #102, but now the tests pass, and I can't think of any reason to keep the old version of Coursier.